### PR TITLE
解决Windows平台编码问题

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,11 @@ $ java -jar Herlang.jar helloworld.her
 要从源代码构建Herlang，你需要安装Java JDK 8或更高版本。
 
 **在Windows上：** 运行 `build.bat`
-(Windows环境会遇到编码的问题，因为java工具在Windows平台的默认编码方式是GBK，但文中代码为UTF-8； 此时可以通过将文件重新保存为GBK编码方式即可，安装命令已同步更改)
+(Windows环境会遇到编码的问题，因为java工具在Windows平台的默认编码方式是跟随系统安装语言的，但文中代码为UTF-8； 此时可以通过将文件重新保存为系统设置的默认编码方式即可，安装命令已同步更改)
 
 **在Mac/Linux上：** 运行 `build.sh`
 
-**在HarmonyOS NEXT上：** 由于 HarmonyOS NEXT 不支持Java JDK，你可能需要使用虚拟机来构建Herlang。
+**在HarmonyOS NEXT上：** 由于 HarmonyOS NEXT 不支持Java JDK，你需要安装Oseasy虚拟机，然后遵循Windows的构建方法
 
 这将编译源代码，将生成的类文件放入 `bin/` 目录中，然后创建一个可运行的 `Herlang.jar`。
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ $ java -jar Herlang.jar helloworld.her
 要从源代码构建Herlang，你需要安装Java JDK 8或更高版本。
 
 **在Windows上：** 运行 `build.bat`
+(Windows环境会遇到编码的问题，因为java工具在Windows平台的默认编码方式是GBK，但文中代码为UTF-8； 此时可以通过将文件重新保存为GBK编码方式即可，安装命令已同步更改)
 
 **在Mac/Linux上：** 运行 `build.sh`
 

--- a/build.bat
+++ b/build.bat
@@ -1,6 +1,6 @@
 @echo off
 if not exist "bin" mkdir bin
-javac -d bin/ src/Herlang.java
-javac -d bin/ src/HerlangExt.java
+javac -encoding UTF-8 -d bin/ src/Herlang.java
+javac -encoding UTF-8 -d bin/ src/HerlangExt.java
 jar cfe Herlang.jar Herlang -C bin/ .
 jar cfe HerlangExt.jar HerlangExt -C bin/ .


### PR DESCRIPTION
作者您好！在windows平台试用时发现，java工具支持的编码格式是GBK，但文中的bat文件及代码均为utf-8，因此提交此patch修复