### PR TITLE
Fix: 修复在Windows平台默认字符集非UTF8时读取代码不正确

### DIFF
--- a/src/Herlang.java
+++ b/src/Herlang.java
@@ -1,4 +1,5 @@
 import java.io.*;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 
 public class Herlang {
@@ -241,7 +242,7 @@ public class Herlang {
  	}
 
 	private static String[] readLines(File file) throws Exception {
-		BufferedReader reader = new BufferedReader(new InputStreamReader(new FileInputStream(file)));
+		BufferedReader reader = new BufferedReader(new InputStreamReader(new FileInputStream(file), StandardCharsets.UTF_8));
 		ArrayList<String> lines = new ArrayList<String>();
 		for(String ln = reader.readLine(); ln != null; ln = reader.readLine()) {
 			lines.add(ln);

--- a/src/HerlangExt.java
+++ b/src/HerlangExt.java
@@ -1,4 +1,5 @@
 import java.io.*;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 
 public class HerlangExt {
@@ -351,7 +352,7 @@ public class HerlangExt {
  	}
 
 	private static String[] readLines(File file) throws Exception {
-		BufferedReader reader = new BufferedReader(new InputStreamReader(new FileInputStream(file)));
+		BufferedReader reader = new BufferedReader(new InputStreamReader(new FileInputStream(file), StandardCharsets.UTF_8));
 		ArrayList<String> lines = new ArrayList<String>();
 		for(String ln = reader.readLine(); ln != null; ln = reader.readLine()) {
 			lines.add(ln);


### PR DESCRIPTION
不以UTF8读取时将出现如下错误：
![error_screenshot](https://github.com/user-attachments/assets/48f6f78c-482b-4218-99fd-2b0fc4be12c6)
